### PR TITLE
add pdb maxUnavailable option

### DIFF
--- a/charts/helm-blue-green/Chart.yaml
+++ b/charts/helm-blue-green/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: helm-blue-green
-version: 0.0.7
+version: 0.0.8
 icon: https://helm.sh/img/helm.svg
 description: Helm Blue Green
 maintainers:

--- a/charts/helm-blue-green/templates/job.yaml
+++ b/charts/helm-blue-green/templates/job.yaml
@@ -65,6 +65,8 @@ spec:
           value: {{ .Values.maxReplicas | quote }}
         - name: MIN_AVAILABLE
           value: {{ .Values.minAvailable | quote }}
+        - name: MAX_UNAVAILABLE
+          value: {{ .Values.maxUnavailable | quote }}
         - name: AVARAGE_UTILIZATION
           value: {{ .Values.averageUtilization | quote }}
 {{ end }}

--- a/charts/helm-blue-green/values.yaml
+++ b/charts/helm-blue-green/values.yaml
@@ -4,7 +4,7 @@ global:
 image:
   registry: docker.io
   repository: paskalmaksim/helm-blue-green
-  tag: v1.1.0
+  tag: v1.1.1
   pullPolicy: IfNotPresent
 
 nodeSelector: {}
@@ -27,6 +27,7 @@ environment: ""
 minReplicas: 2
 maxReplicas: 10
 minAvailable: 1
+maxUnavailable: 0
 averageUtilization: 60
 
 config: ""

--- a/e2e/testdata/test1.yaml
+++ b/e2e/testdata/test1.yaml
@@ -16,7 +16,8 @@ hpa:
   averageUtilization: 50
 
 pdb:
-  minAvailable: 1
+  minAvailable: 0
+  maxUnavailable: 1
 
 deployments:
 - name: http-echo1


### PR DESCRIPTION
pod distruption budget can be created with maxUnavailable option, usage with helm values
```yaml
minAvailable: 0
maxUnavailable: 1
```

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>