### PR TITLE
use MaxUnavailable in PDB

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -476,7 +476,7 @@ type Type struct {
 	Metadata                 map[string]string
 }
 
-func (t *Type) Normalize() {
+func (t *Type) Normalize() { //nolint:cyclop
 	setBudgetInSeconds := func(a []*PromQLMetric) {
 		localDefaultBudgetInSeconds := defaultBudgetInSeconds
 
@@ -498,6 +498,11 @@ func (t *Type) Normalize() {
 	setBudgetInSeconds(t.Canary.Phase2.QualityGate.BadSamplesMetrics)
 	setBudgetInSeconds(t.Canary.Phase2.QualityGate.TotalSamplesMetrics)
 
+	// if user set both values, we need to use only one
+	if t.Pdb.MinAvailable > 0 && t.Pdb.MaxUnavailable > 0 {
+		t.Pdb.MinAvailable = 0
+	}
+
 	for _, deployment := range t.Deployments {
 		if deployment.MinReplicas == 0 {
 			deployment.MinReplicas = t.MinReplicas
@@ -510,6 +515,12 @@ func (t *Type) Normalize() {
 		if deployment.Hpa != nil {
 			if deployment.Hpa.AverageUtilization == 0 {
 				deployment.Hpa.AverageUtilization = defaultAverageUtilization
+			}
+		}
+
+		if deployment.Pdb != nil {
+			if deployment.Pdb.MinAvailable > 0 && deployment.Pdb.MaxUnavailable > 0 {
+				deployment.Pdb.MinAvailable = 0
 			}
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/maksim-paskal/helm-blue-green/pkg/types"
 )
 
-func TestConfig(t *testing.T) {
+func TestConfig(t *testing.T) { //nolint:cyclop
 	ctx := context.Background()
 
 	t.Setenv("NAMESPACE", "default")
@@ -62,6 +62,24 @@ func TestConfig(t *testing.T) {
 
 	if want := int32(22); want != config.Get().Deployments[1].MinReplicas {
 		t.Fatalf("MinReplicas for 0 is not %d", want)
+	}
+
+	if !(config.Get().Pdb.MinAvailable == 0 && config.Get().Pdb.MaxUnavailable == 2) {
+		t.Fatal("Pdb is not 0/2")
+	}
+
+	d := config.Get().Deployments
+
+	if len(d) != 2 {
+		t.Fatal("Deployments length is not 2")
+	}
+
+	if !(d[0].Pdb.MinAvailable == 0 && d[0].Pdb.MaxUnavailable == 2) {
+		t.Fatal("Pdb is not 0/2")
+	}
+
+	if !(d[1].Pdb.MinAvailable == 3 && d[1].Pdb.MaxUnavailable == 0) {
+		t.Fatal("Pdb is not 3/0")
 	}
 }
 

--- a/pkg/config/testdata/test_config.yaml
+++ b/pkg/config/testdata/test_config.yaml
@@ -1,8 +1,15 @@
 name: testName
 
+pdb:
+  minAvailable: 1
+  maxUnavailable: 2
+
 deployments:
 - name: test01
 - name: test02
+  pdb:
+    minAvailable: 3
+    maxUnavailable: 0
 
 services:
 - name: test01


### PR DESCRIPTION
If user set both of MinAvailable and MaxUnavailable in PDP - it's a critical error, on validation step will use only MaxUnavailable value